### PR TITLE
Fixed closing

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -61,7 +61,7 @@
 			return a;
 		});
 	const buildText = () => {
-		finalText = `${data.anrede},\n\n${data.einleitung}\n${data.beschwerde.text}\n${data.appell.text}\n\n${data.gruss},\n${data.name}`;
+		finalText = `${data.anrede},\n\n${data.einleitung}\n${data.beschwerde.text}\n${data.appell.text}\n\n${data.gruss}\n${data.name}`;
 	};
 	const buildMailToLink = (empfaenger: string, preview: string): string => {
 		if (empfaenger === "" || preview === "") return "";


### PR DESCRIPTION
After "Beste Grüße" or other closings in a letter or e-mail there is no comma needed. Removed the comma.